### PR TITLE
Refactor Wordle solver and add Python demo UI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,155 @@
+import os
+import random
+import json
+import urllib.request
+import urllib.error
+from typing import List
+
+Feedback = List[str]
+
+DEFAULT_VOCAB = [
+    "crane",
+    "slate",
+    "flint",
+    "pride",
+    "crown",
+    "glare",
+    "shine",
+    "grape",
+    "stone",
+    "brink",
+]
+
+
+def fetch_word_from_ai() -> str:
+    key = os.getenv("OPENAI_API_KEY")
+    if not key:
+        raise RuntimeError("OPENAI_API_KEY is not set")
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/chat/completions",
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {key}",
+        },
+        data=json.dumps(
+            {
+                "model": "gpt-4o-mini",
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": "Respond with a single random common five-letter English word in lowercase. No explanations.",
+                    },
+                    {"role": "user", "content": "word"},
+                ],
+                "max_tokens": 5,
+                "temperature": 1,
+            }
+        ).encode("utf-8"),
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.load(resp)
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"OpenAI request failed: {exc}")
+    word = data.get("choices", [{}])[0].get("message", {}).get("content", "").strip().lower()
+    if not word.isalpha() or len(word) != 5:
+        raise RuntimeError("Invalid word received from OpenAI")
+    return word
+
+
+def evaluate_guess(target: str, guess: str) -> Feedback:
+    result: Feedback = ["absent"] * 5
+    remaining: List[str] = []
+    for i, (g, t) in enumerate(zip(guess, target)):
+        if g == t:
+            result[i] = "correct"
+        else:
+            remaining.append(t)
+    for i, g in enumerate(guess):
+        if result[i] == "correct":
+            continue
+        if g in remaining:
+            result[i] = "present"
+            remaining.remove(g)
+    return result
+
+
+class WordleRLSolver:
+    def __init__(self, vocabulary: List[str], alpha: float = 0.1, epsilon: float = 0.1):
+        self.vocab = vocabulary
+        self.alpha = alpha
+        self.epsilon = epsilon
+        self.q_table = [[0.0] * 5 for _ in range(26)]
+
+    def _letter_index(self, letter: str) -> int:
+        return ord(letter) - 97
+
+    def _score(self, word: str) -> float:
+        return sum(self.q_table[self._letter_index(c)][i] for i, c in enumerate(word))
+
+    def _choose(self, eligible: List[str]) -> str:
+        if random.random() < self.epsilon:
+            return random.choice(eligible)
+        best = eligible[0]
+        best_score = self._score(best)
+        for w in eligible[1:]:
+            s = self._score(w)
+            if s > best_score:
+                best_score, best = s, w
+        return best
+
+    def _matches(self, word: str, guess: str, feedback: Feedback) -> bool:
+        for i, (g, fb) in enumerate(zip(guess, feedback)):
+            w = word[i]
+            if fb == "correct" and w != g:
+                return False
+            if fb == "present":
+                if w == g or g not in word:
+                    return False
+            if fb == "absent" and g in word:
+                return False
+        return True
+
+    def train(self, target: str, max_steps: int = 6) -> List[str]:
+        eligible = self.vocab[:]
+        guesses: List[str] = []
+        for _ in range(max_steps):
+            guess = self._choose(eligible)
+            guesses.append(guess)
+            feedback = evaluate_guess(target, guess)
+            for i, (g, fb) in enumerate(zip(guess, feedback)):
+                idx = self._letter_index(g)
+                reward = 1 if fb == "correct" else 0.5 if fb == "present" else 0
+                self.q_table[idx][i] += self.alpha * (reward - self.q_table[idx][i])
+            eligible = [w for w in eligible if self._matches(w, guess, feedback)]
+            if guess == target:
+                break
+        return guesses
+
+
+def print_board(guesses: List[str], target: str) -> None:
+    color = {"correct": "\x1b[42m", "present": "\x1b[43m", "absent": "\x1b[100m"}
+    reset = "\x1b[0m"
+    for guess in guesses:
+        fb = evaluate_guess(target, guess)
+        line = "".join(f"{color[f]} {c.upper()} {reset}" for c, f in zip(guess, fb))
+        print(line)
+
+
+def main() -> None:
+    solver = WordleRLSolver(DEFAULT_VOCAB)
+    try:
+        target = fetch_word_from_ai()
+    except Exception:
+        target = random.choice(DEFAULT_VOCAB)
+    guesses = solver.train(target)
+    print_board(guesses, target)
+    if guesses and guesses[-1] == target:
+        print(f"Solved in {len(guesses)} guesses!")
+    else:
+        print(f"Failed to solve. Target word was {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/wordle/feedback.ts
+++ b/src/wordle/feedback.ts
@@ -1,0 +1,28 @@
+export type Feedback = 'correct' | 'present' | 'absent';
+
+export function evaluateGuess(target: string, guess: string): Feedback[] {
+  const result: Feedback[] = Array<Feedback>(5).fill('absent');
+  const targetLetters = target.split('');
+  const guessLetters = guess.split('');
+
+  const remaining: string[] = [];
+  for (let i = 0; i < 5; i++) {
+    const g = guessLetters[i]!;
+    const t = targetLetters[i]!;
+    if (g === t) {
+      result[i] = 'correct';
+    } else {
+      remaining.push(t);
+    }
+  }
+
+  for (let i = 0; i < 5; i++) {
+    if (result[i] === 'correct') continue;
+    const idx = remaining.indexOf(guessLetters[i]!);
+    if (idx !== -1) {
+      result[i] = 'present';
+      remaining.splice(idx, 1);
+    }
+  }
+  return result;
+}

--- a/src/wordle/openAI.ts
+++ b/src/wordle/openAI.ts
@@ -1,0 +1,44 @@
+export async function fetchWordFromAI(): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY is not set');
+  }
+  const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [
+        {
+          role: 'system',
+          content:
+            'Respond with a single random common five-letter English word in lowercase. No explanations.',
+        },
+        { role: 'user', content: 'word' },
+      ],
+      max_tokens: 5,
+      temperature: 1,
+    }),
+  });
+  const raw: unknown = await resp.json();
+  interface ChatCompletionResponse {
+    choices: { message?: { content?: string } }[];
+  }
+  if (
+    typeof raw !== 'object' ||
+    raw === null ||
+    !('choices' in raw) ||
+    !Array.isArray((raw as { choices: unknown }).choices)
+  ) {
+    throw new Error('Invalid response structure from OpenAI');
+  }
+  const data = raw as ChatCompletionResponse;
+  const word = data.choices[0]?.message?.content?.trim().toLowerCase() ?? '';
+  if (!/^[a-z]{5}$/.test(word)) {
+    throw new Error('Invalid word received from OpenAI');
+  }
+  return word;
+}

--- a/src/wordle/solver.ts
+++ b/src/wordle/solver.ts
@@ -1,0 +1,108 @@
+import { fetchWordFromAI } from './openAI';
+import { evaluateGuess } from './feedback';
+import type { Feedback } from './feedback';
+
+export class WordleRLSolver {
+  private qTable: number[][]; // [letter][position]
+  private vocabulary: string[];
+  private alpha: number;
+  private epsilon: number;
+
+  constructor(vocabulary: string[], alpha = 0.1, epsilon = 0.1) {
+    this.vocabulary = vocabulary;
+    this.alpha = alpha;
+    this.epsilon = epsilon;
+    this.qTable = Array.from({ length: 26 }, () => Array<number>(5).fill(0));
+  }
+
+  private letterIndex(letter: string): number {
+    return letter.charCodeAt(0) - 97;
+  }
+
+  private score(word: string): number {
+    let total = 0;
+    for (let i = 0; i < 5; i++) {
+      const idx = this.letterIndex(word[i]!);
+      const row = this.qTable[idx]!;
+      total += row[i]!;
+    }
+    return total;
+  }
+
+  private choose(eligible: string[]): string {
+    if (Math.random() < this.epsilon) {
+      return eligible[Math.floor(Math.random() * eligible.length)]!;
+    }
+    let best = eligible[0]!;
+    let bestScore = this.score(best);
+    for (const word of eligible.slice(1)) {
+      const s = this.score(word);
+      if (s > bestScore) {
+        bestScore = s;
+        best = word;
+      }
+    }
+    return best;
+  }
+
+  train(target: string, maxSteps = 6): string[] {
+    let eligible = [...this.vocabulary];
+    const guesses: string[] = [];
+    for (let step = 0; step < maxSteps; step++) {
+      const guess = this.choose(eligible);
+      guesses.push(guess);
+      const feedback = evaluateGuess(target, guess);
+
+      for (let i = 0; i < 5; i++) {
+        const idx = this.letterIndex(guess[i]!);
+        let reward = 0;
+        if (feedback[i] === 'correct') reward = 1;
+        else if (feedback[i] === 'present') reward = 0.5;
+        const row = this.qTable[idx]!;
+        row[i]! += this.alpha * (reward - row[i]!);
+      }
+
+      eligible = eligible.filter((word) => this.matches(word, guess, feedback));
+
+      if (guess === target) break;
+    }
+    return guesses;
+  }
+
+  private matches(word: string, guess: string, feedback: Feedback[]): boolean {
+    for (let i = 0; i < 5; i++) {
+      const letter = guess[i]!;
+      const w = word[i]!;
+      switch (feedback[i]) {
+        case 'correct':
+          if (w !== letter) return false;
+          break;
+        case 'present':
+          if (w === letter || !word.includes(letter)) return false;
+          break;
+        case 'absent':
+          if (word.includes(letter)) return false;
+          break;
+      }
+    }
+    return true;
+  }
+
+  async trainWithAI(maxSteps = 6): Promise<string[]> {
+    const target = await fetchWordFromAI();
+    return this.train(target, maxSteps);
+  }
+}
+
+export const DEFAULT_VOCAB = [
+  'crane',
+  'slate',
+  'flint',
+  'pride',
+  'crown',
+  'glare',
+  'shine',
+  'grape',
+  'stone',
+  'brink',
+];


### PR DESCRIPTION
## Summary
- extract OpenAI and feedback helpers into separate modules
- keep RL solver in its own module and import new helpers
- add `main.py` Python script showing solver guesses in a small Wordle UI

## Testing
- `pnpm exec eslint src/wordle/feedback.ts src/wordle/openAI.ts src/wordle/solver.ts`
- `pnpm exec tsc --noEmit src/wordle/feedback.ts src/wordle/openAI.ts src/wordle/solver.ts`
- `python main.py`

------
https://chatgpt.com/codex/tasks/task_e_68ad3efba2e08321839e2b3637c1e270